### PR TITLE
* RequestHeader.cs: Changed WebSocket response header to always use

### DIFF
--- a/Nonocast.Connect/ServerImpl/RequestHeader.cs
+++ b/Nonocast.Connect/ServerImpl/RequestHeader.cs
@@ -53,13 +53,16 @@ namespace Nonocast.Connect {
 			}
 		}
 
+		public static readonly string NewLine = "\r\n"; //websockets specs demand \r\n at header line end
+
 		public override string ToString() {
 			var sb = new StringBuilder();
-			sb.AppendLine(StartLine);
+			sb.Append(StartLine);
+			sb.Append (NewLine);
 			foreach (var each in Properties) {
-				sb.AppendFormat("{0}: {1}{2}", each.Key, each.Value, Environment.NewLine);
+				sb.AppendFormat("{0}: {1}{2}", each.Key, each.Value, NewLine);
 			}
-			sb.AppendLine();
+			sb.Append (NewLine);
 			return sb.ToString();
 		}
 

--- a/Nonocast.Connect/ServerImpl/Response.cs
+++ b/Nonocast.Connect/ServerImpl/Response.cs
@@ -176,6 +176,7 @@ namespace Nonocast.Connect {
 			Mimes.Add("wma", "audio/x-ms-wma");
 			Mimes.Add("wmv", "video/x-ms-wmv");
 			Mimes.Add("apk", "application/vnd.android.package-archive");
+			Mimes.Add(".woff", "application/font-woff");
 		}
 
 		private Dictionary<string, object> headers;


### PR DESCRIPTION
  \r\n for newline because the websocket protocol requires it. Before
  it was using the environment's definition of a new line which means
  it would work in Windows but if run under Linux or OS X stricter
  browsers would reject the server response.
- Response.cs: Added Web Fonts to mimetype
  ".woff", "application/font-woff"
